### PR TITLE
OEP-70: Shared Design Collateral Contribution Requirements

### DIFF
--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -85,7 +85,7 @@ Specification
 *************
 
 1. **Contribution requirement.** Any accepted product proposal that includes
-   design work MUST submit its design collateral to the shared Open edX Figma
+   design work must submit its design collateral to the shared Open edX Figma
    instance for the project to be considered complete. This SHOULD be captured
    as an expectation in future design contributions.
 

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -55,7 +55,7 @@ contributing them is strongly encouraged.
 Motivation
 **********
 
-Historically, Open edX has had no shared source of truth for design resources.
+Historically, the Open edX project has had no shared source of truth for design resources.
 This created three recurring problems:
 
 1. **Duplicated, siloed work.** Every provider with design capacity maintained

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -86,7 +86,7 @@ Specification
 
 1. **Contribution requirement.** Any accepted product proposal that includes
    design work must submit its design collateral to the shared Open edX Figma
-   instance for the project to be considered complete. This SHOULD be captured
+   instance for the project to be considered complete. This should be captured
    as an expectation in future design contributions.
 
    - **Note**: the contribution model is actively maintained by the `Design
@@ -95,7 +95,7 @@ Specification
      allow for flexibility and openness in shared design collateral governance
      going forward.
 
-2. **Open access.** Contributed files MUST be openly accessible and reusable by
+2. **Open access.** Contributed files must be openly accessible and reusable by
    the community (viewable and exportable, under an open license) so that
    anyone can reference or build on them, including for open-format export and
    agentic prototyping.

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -150,7 +150,6 @@ Rejected Alternatives
 Open Questions
 **************
 
-- Identification of the Arbiter.
 - Exact licensing terms and access mechanics for contributed files.
 - Whether the requirement applies to all design contributions or a defined
   subset or tier.

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -102,7 +102,7 @@ Specification
 #. **Workflow parity with code.** Contributions happen in branches within the
    shared instance. Design maintainers review work-in-progress and provide
    feedback before it is merged into the live product-area files, mirroring the
-   code-maintainer model. Frozen release files are published to the Figma
+   code-maintainer model. Design files for each named release, frozen at the time of release cut, will be published to the Figma
    Community as part of the release (Build-Test-Release, or BTR) process.
 #. **Roles.** Each proposal and contribution stream has identified Author(s)
    and an Arbiter, plus Design Maintainers (analogous to code maintainers)

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -160,18 +160,8 @@ Open Questions
 Change History
 **************
 
-2026-07-27
-==========
-
-* Converted the working draft to the OEP format and claimed the number OEP-70.
-
-2026-07-14 - 2026-07-20
-=======================
-
-* Editing some details, asking for some community input.
-
 2026-07-14
 ==========
 
-* Initial draft synthesized from recent Shared Design Collateral syncs and the
-  community provider-adoption debrief.
+* Document created.
+* `Pull request #813 <https://github.com/openedx/openedx-proposals/pull/813>`_

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -136,17 +136,6 @@ Rationale
 - **Reduced duplication.** Shared, reusable atoms, molecules, and full views
   cut redundant design spend across providers.
 
-Rejected Alternatives
-*********************
-
-- **Voluntary adoption only.** Already attempted through direct and
-  working-group outreach. It produced enthusiasm but insufficient
-  follow-through, leaving maintenance concentrated in a single provider.
-- **Any single provider as ongoing design arbiter.** Rejected. The goal is a
-  shared community norm and capability, not a gatekeeper. Time-boxed resourcing
-  to help providers through first-time heavy lifts, plus reusable training, is
-  a complementary effort, not a permanent arbitration role.
-
 Open Questions
 **************
 

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -58,13 +58,13 @@ Motivation
 Historically, the Open edX project has had no shared source of truth for design resources.
 This created three recurring problems:
 
-1. **Duplicated, siloed work.** Every provider with design capacity maintained
+#. **Duplicated, siloed work.** Every provider with design capacity maintained
    separate, out-of-date versions of designs, and teams regularly recreated
    designs from scratch for existing Open edX apps.
-2. **Ambiguous intent.** Without a design source of truth, engineers could not
+#. **Ambiguous intent.** Without a design source of truth, engineers could not
    differentiate intentional design decisions from provider-specific Figma
    quirks or accidents.
-3. **High onboarding cost.** New design contributors had nowhere to start and
+#. **High onboarding cost.** New design contributors had nowhere to start and
    no history of decisions to build on, making community onboarding very
    difficult.
 
@@ -84,7 +84,7 @@ of the shared instance.
 Specification
 *************
 
-1. **Contribution requirement.** Any accepted product proposal that includes
+#. **Contribution requirement.** Any accepted product proposal that includes
    design work must submit its design collateral to the shared Open edX Figma
    instance for the project to be considered complete. This should be captured
    as an expectation in future design contributions.
@@ -95,19 +95,19 @@ Specification
      allow for flexibility and openness in shared design collateral governance
      going forward.
 
-2. **Open access.** Contributed files must be openly accessible and reusable by
+#. **Open access.** Contributed files must be openly accessible and reusable by
    the community (viewable and exportable, under an open license) so that
    anyone can reference or build on them, including for open-format export and
    agentic prototyping.
-3. **Workflow parity with code.** Contributions happen in branches within the
+#. **Workflow parity with code.** Contributions happen in branches within the
    shared instance. Design maintainers review work-in-progress and provide
    feedback before it is merged into the live product-area files, mirroring the
    code-maintainer model. Frozen release files are published to the Figma
    Community as part of the release (Build-Test-Release, or BTR) process.
-4. **Roles.** Each proposal and contribution stream has identified Author(s)
+#. **Roles.** Each proposal and contribution stream has identified Author(s)
    and an Arbiter, plus Design Maintainers (analogous to code maintainers)
    responsible for reviewing and merging contributions.
-5. **Communication and relay.** This expectation is relayed to current and
+#. **Communication and relay.** This expectation is relayed to current and
    future contribution owners and providers, and at minimum current
    contribution owners are asked to return files they worked on to the shared
    instance.

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -1,0 +1,176 @@
+.. _OEP-70 Shared Design Collateral Contribution Requirements:
+
+OEP-70: Shared Design Collateral Contribution Requirements
+##########################################################
+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :ref:`OEP-0070 <OEP-70 Shared Design Collateral Contribution Requirements>`
+   * - Title
+     - Shared Design Collateral Contribution Requirements
+   * - Last Modified
+     - 2026-07-27
+   * - Authors
+     - Sam Daitzman <sam.daitzman@schema.education>
+   * - Arbiter
+     - TBD (Needs an arbiter)
+   * - Status
+     - Draft
+   * - Type
+     - Process
+   * - Created
+     - 2026-07-14
+   * - Review Period
+     - TBD (recommended 2 weeks)
+   * - References
+     - Open edX shared Figma instance; `Open edX Shared Design Collateral
+       <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_;
+       :ref:`OEP-1 <OEP-1 OEP Purpose and Guidelines>`
+
+.. contents::
+   :local:
+   :depth: 1
+
+Abstract
+********
+
+This OEP establishes that design collateral contributed to the Open edX
+platform must be contributed back into the shared Open edX Figma instance,
+under open access for reuse, as a condition of the work being considered
+complete. This applies to all design contributions to the platform. It applies
+the same collaboration model the community already relies on for code to
+design: a single source of truth, versioned work in branches, and maintainer
+review before merge.
+
+Following the precedent of prior *amnesty*-style process changes (e.g., the
+:ref:`lint amnesty <OEP-34 Lint Amnesty>`),
+the requirement applies going forward only: existing and legacy design files
+are granted amnesty and are not required to be retroactively migrated to match
+the structure or format of the standard reference design collateral, though
+contributing them is strongly encouraged.
+
+Motivation
+**********
+
+Historically, Open edX has had no shared source of truth for design resources.
+This created three recurring problems:
+
+1. **Duplicated, siloed work.** Every provider with design capacity maintained
+   separate, out-of-date versions of designs, and teams regularly recreated
+   designs from scratch for existing Open edX apps.
+2. **Ambiguous intent.** Without a design source of truth, engineers could not
+   differentiate intentional design decisions from provider-specific Figma
+   quirks or accidents.
+3. **High onboarding cost.** New design contributors had nowhere to start and
+   no history of decisions to build on, making community onboarding very
+   difficult.
+
+The shared Open edX Figma instance now provides that source of truth, with
+resources across nearly all platform areas and modern, reusable file structures
+aligned to Paragon. However, **adoption is now the central risk to future Open
+edX community shared/open design efforts.** Strong in-person interest has not
+translated into active use of the shared instance, and some active
+contributions have built on openly shared components without contributing their
+new files back or making them available for open reuse.
+
+Without a community-wide norm, a single provider effectively becomes the only
+party keeping the files current, which is not sustainable. Codifying a
+contribution expectation is the most direct lever to secure the long-term value
+of the shared instance.
+
+Specification
+*************
+
+1. **Contribution requirement.** Any accepted product proposal that includes
+   design work MUST submit its design collateral to the shared Open edX Figma
+   instance for the project to be considered complete. This SHOULD be captured
+   as an expectation in future design contributions.
+
+   - **Note**: the contribution model is actively maintained by the `Design
+     <https://openedx.atlassian.net/wiki/x/KwDR3w>`_ and `Frontend
+     <https://openedx.atlassian.net/wiki/x/9YYuu>`_ Working Groups, which will
+     allow for flexibility and openness in shared design collateral governance
+     going forward.
+
+2. **Open access.** Contributed files MUST be openly accessible and reusable by
+   the community (viewable and exportable, under an open license) so that
+   anyone can reference or build on them, including for open-format export and
+   agentic prototyping.
+3. **Workflow parity with code.** Contributions happen in branches within the
+   shared instance. Design maintainers review work-in-progress and provide
+   feedback before it is merged into the live product-area files, mirroring the
+   code-maintainer model. Frozen release files are published to the Figma
+   Community as part of the release (Build-Test-Release, or BTR) process.
+4. **Roles.** Each proposal and contribution stream has identified Author(s)
+   and an Arbiter, plus Design Maintainers (analogous to code maintainers)
+   responsible for reviewing and merging contributions.
+5. **Communication and relay.** This expectation is relayed to current and
+   future contribution owners and providers, and at minimum current
+   contribution owners are asked to return files they worked on to the shared
+   instance.
+
+Backward Compatibility
+**********************
+
+This OEP applies to new and future work only: **no regressions.** Design work
+that predates this proposal is granted amnesty: providers are not required to
+retroactively migrate legacy files into the shared instance, though doing so is
+strongly encouraged. This mirrors the community's linting-amnesty precedent,
+where new violations are disallowed while pre-existing ones are forgiven.
+
+Rationale
+*********
+
+- **Proven model.** Code contributors already benefit from a shared source of
+  truth, versioning, parallel work, central issue tracking, and a shared doc
+  site (Paragon). Extending the same practices to design is a natural, low-risk
+  step.
+- **Lower barrier to entry.** A shared, openly licensed instance lets new
+  contributors start from existing work instead of an empty canvas,
+  accelerating onboarding.
+- **Cleaner handoffs.** A design source of truth lets engineers distinguish
+  intentional decisions from accidents, reducing guesswork and rework.
+- **Reduced duplication.** Shared, reusable atoms, molecules, and full views
+  cut redundant design spend across providers.
+
+Rejected Alternatives
+*********************
+
+- **Voluntary adoption only.** Already attempted through direct and
+  working-group outreach. It produced enthusiasm but insufficient
+  follow-through, leaving maintenance concentrated in a single provider.
+- **Any single provider as ongoing design arbiter.** Rejected. The goal is a
+  shared community norm and capability, not a gatekeeper. Time-boxed resourcing
+  to help providers through first-time heavy lifts, plus reusable training, is
+  a complementary effort, not a permanent arbitration role.
+
+Open Questions
+**************
+
+- Identification of the Arbiter.
+- Exact licensing terms and access mechanics for contributed files.
+- Whether the requirement applies to all design contributions or a defined
+  subset or tier.
+- The support and resourcing model (e.g., a pilot and training) to help
+  providers meet the requirement.
+
+Change History
+**************
+
+2026-07-27
+==========
+
+* Converted the working draft to the OEP format and claimed the number OEP-70.
+
+2026-07-14 - 2026-07-20
+=======================
+
+* Editing some details, asking for some community input.
+
+2026-07-14
+==========
+
+* Initial draft synthesized from recent Shared Design Collateral syncs and the
+  community provider-adoption debrief.

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -25,9 +25,10 @@ OEP-70: Shared Design Collateral Contribution Requirements
    * - Review Period
      - TBD (recommended 2 weeks)
    * - References
-     - Open edX shared Figma instance; `Open edX Shared Design Collateral
-       <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_;
-       :ref:`OEP-1 <OEP-1 OEP Purpose and Guidelines>`
+     - | Open edX shared Figma instance
+       | `Open edX Shared Design Collateral
+       <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_
+       |  :ref:OEP-1 OEP Purpose and Guidelines`
 
 .. contents::
    :local:

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -26,8 +26,7 @@ OEP-70: Shared Design Collateral Contribution Requirements
      - TBD (recommended 2 weeks)
    * - References
      - | Open edX shared Figma instance
-       | `Open edX Shared Design Collateral
-       <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_
+       | `Open edX Shared Design Collateral <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_
        |  :ref:OEP-1 OEP Purpose and Guidelines`
 
 .. contents::

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -11,11 +11,11 @@ OEP-70: Shared Design Collateral Contribution Requirements
    * - Title
      - Shared Design Collateral Contribution Requirements
    * - Last Modified
-     - 2026-07-27
+     - 2026-09-01
    * - Authors
      - Sam Daitzman <sam.daitzman@schema.education>
    * - Arbiter
-     - TBD (Needs an arbiter)
+     - Sarina Canelake <sarina@axim.org>
    * - Status
      - Draft
    * - Type

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -67,18 +67,11 @@ This created three recurring problems:
    no history of decisions to build on, making community onboarding very
    difficult.
 
-The shared Open edX Figma instance now provides that source of truth, with
+The shared Open edX Figma instance will provide that source of truth, with
 resources across nearly all platform areas and modern, reusable file structures
-aligned to Paragon. However, **adoption is now the central risk to future Open
-edX community shared/open design efforts.** Strong in-person interest has not
-translated into active use of the shared instance, and some active
-contributions have built on openly shared components without contributing their
-new files back or making them available for open reuse.
-
-Without a community-wide norm, a single provider effectively becomes the only
-party keeping the files current, which is not sustainable. Codifying a
-contribution expectation is the most direct lever to secure the long-term value
-of the shared instance.
+aligned to Paragon. An expectation of continual contribution to this shared instance,
+from all parties working on design collateral, mirrors the norms that the project
+already has around code contributions.
 
 Specification
 *************

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -94,11 +94,14 @@ Specification
    the community (viewable and exportable, under an open license) so that
    anyone can reference or build on them, including for open-format export and
    agentic prototyping.
-#. **Workflow parity with code.** Contributions happen in branches within the
-   shared instance. Design maintainers review work-in-progress and provide
-   feedback before it is merged into the live product-area files, mirroring the
-   code-maintainer model. Design files for each named release, frozen at the time of release cut, will be published to the Figma
-   Community as part of the release (Build-Test-Release, or BTR) process.
+#. **Workflow parity with code.** Contributions happen in `Figma branches
+   <https://openedx.atlassian.net/wiki/x/AYAOeAE>`_
+   within the shared instance. Design maintainers review work-in-progress and
+   provide feedback before it is merged into the live product-area files,
+   mirroring the code-maintainer model. Design files for each named release,
+   frozen at the time of release cut, will be published to the Figma Community
+   as part of the release (Build-Test-Release, or BTR) process, so that any
+   consumer can point at a stable, versioned library for a given release.
 #. **Roles.** Each proposal and contribution stream has identified Author(s)
    and an Arbiter, plus Design Maintainers (analogous to code maintainers)
    responsible for reviewing and merging contributions.

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -127,7 +127,9 @@ Rationale
   intentional decisions from accidents, reducing guesswork and rework.
 - **Reduced duplication.** Shared, reusable atoms, molecules, and full views
   cut redundant design spend across providers.
- - **Adherence to standards.** Ensuring that all designs use the same, reusable elements across the platform enables all components to natively follow accessibility, internationalization, and other standards.
+- **Adherence to standards.** Ensuring that all designs use the same, reusable
+  elements across the platform enables all components to natively follow
+  accessibility, internationalization, and other standards.
 
 Open Questions
 **************

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -105,10 +105,6 @@ Specification
 #. **Roles.** Each proposal and contribution stream has identified Author(s)
    and an Arbiter, plus Design Maintainers (analogous to code maintainers)
    responsible for reviewing and merging contributions.
-#. **Communication and relay.** This expectation is relayed to current and
-   future contribution owners and providers, and at minimum current
-   contribution owners are asked to return files they worked on to the shared
-   instance.
 
 Backward Compatibility
 **********************

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -54,8 +54,8 @@ contributing them is strongly encouraged.
 Motivation
 **********
 
-Historically, the Open edX project has had no shared source of truth for design resources.
-This created three recurring problems:
+Historically, the Open edX project has had no shared source of truth for design
+resources. This created four recurring problems:
 
 #. **Duplicated, siloed work.** Every provider with design capacity maintained
    separate, out-of-date versions of designs, and teams regularly recreated
@@ -66,6 +66,9 @@ This created three recurring problems:
 #. **High onboarding cost.** New design contributors had nowhere to start and
    no history of decisions to build on, making community onboarding very
    difficult.
+#. **Divergence from standards.** Designs built from scratch, potentially with
+   custom Figma components that diverge from Paragon over time, can compromise
+   accessibility, internationalization, and other important standards.
 
 The shared Open edX Figma instance will provide that source of truth, with
 resources across nearly all platform areas and modern, reusable file structures

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -27,7 +27,7 @@ OEP-70: Shared Design Collateral Contribution Requirements
    * - References
      - | Open edX shared Figma instance
        | `Open edX Shared Design Collateral <https://openedx.atlassian.net/wiki/x/A4BtbwE>`_
-       |  :ref:OEP-1 OEP Purpose and Guidelines`
+       |  :ref:`OEP-1 OEP Purpose and Guidelines`
 
 .. contents::
    :local:

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -134,6 +134,7 @@ Rationale
   intentional decisions from accidents, reducing guesswork and rework.
 - **Reduced duplication.** Shared, reusable atoms, molecules, and full views
   cut redundant design spend across providers.
+ - **Adherence to standards.** Ensuring that all designs use the same, reusable elements across the platform enables all components to natively follow accessibility, internationalization, and other standards.
 
 Open Questions
 **************

--- a/oeps/processes/oep-0070-proc-shared-design-collateral.rst
+++ b/oeps/processes/oep-0070-proc-shared-design-collateral.rst
@@ -122,6 +122,7 @@ where new violations are disallowed while pre-existing ones are forgiven.
 Rationale
 *********
 
+- **Open-source as a priority.** The Open edX project is licensed under open-source licenses. Open-source means making software code public so anyone can view, use, modify, and share it. Making our design collateral similarly open-source enables community innovation on the same scale as the code itself.
 - **Proven model.** Code contributors already benefit from a shared source of
   truth, versioning, parallel work, central issue tracking, and a shared doc
   site (Paragon). Extending the same practices to design is a natural, low-risk


### PR DESCRIPTION
## Summary

This OEP establishes that contributions to the Open edX platform that include design work must be contributed back into the shared Open edX Figma instance, under open access for reuse. It applies the collaboration model the community already relies on for code contributions to design contributions. Design contributions should have a single source of truth, versioned work in branches, and maintainer review before merge.

It includes a requirement that "Any accepted product proposal that includes design work must submit its design collateral to the shared Open edX Figma instance for the project to be considered complete."

## Amnesty for existing work

The requirement applies going forward only. Design work predating this proposal is granted amnesty: contributors are **not** required to retroactively migrate legacy files to meet the format of standard reference files, though doing so is encouraged. This mirrors the precedent set by OEP-34 (Lint Amnesty), where new violations are disallowed while pre-existing ones are forgiven.

## Status and what I'm asking for

Status is **Draft**, and I'm looking for an **Arbiter**. Once an Arbiter is assigned we can set review dates and move this to Under Review; I've suggested a two-week review period in the header.

## Open questions

These are called out in the OEP itself and I'd especially value input on them:

- Exact licensing terms and access mechanics for contributed files.
- Whether the requirement applies to all design contributions or a defined subset or tier.
     - In particular, the question of which code-level contributions will result in a significant enough change in UI that they should require design maintainer review.
- The support and resourcing model (e.g. a pilot and training) to help contributors meet the requirement.
- Does the contribution process balance ease of contributing to the shared Figma instance with a reasonable degree of design review and access control?
- How might this process adapt in the future, particularly as design tooling shifts over time?

## Number

Claiming **70**; 69 is claimed by #805.

## Review 👀

**Open**: TBD
**Closes**: TBD

Rendered preview will be linked by the `docs/readthedocs.org:open-edx-proposals` check once it builds.

## AI Note 🤖

Per the Open edX AI Contribution Policy: I wrote the substance of this proposal myself, drafting it from recent Shared Design Collateral project meetings, working group notes, and similar. I used Claude Code to provide some structure and phrasing options, and to convert that draft into the repository's reStructuredText OEP format, and generate the initial version of this ticket summary. I've closely reviewed all of this content and corrected issues I noticed.