### PR TITLE
docs: frontend branching and publishing ADRs

### DIFF
--- a/oeps/architectural-decisions/oep-0065/decisions/0004-merging-frontend-base.rst
+++ b/oeps/architectural-decisions/oep-0065/decisions/0004-merging-frontend-base.rst
@@ -1,0 +1,133 @@
+.. _Merging frontend-base:
+
+Merging frontend-base
+#####################
+
+Status
+******
+
+Accepted
+
+Summary
+*******
+
+This ADR describes how a repository's ``frontend-base`` conversion branch becomes
+its main branch, what governs its branches once it has, and where the
+:term:`micro-frontend <Micro-frontend>` it replaces goes on living.
+
+Context
+*******
+
+Converting a ``frontend-app-*`` repository into an :term:`App Repository`, as
+:ref:`ADR 0002 <Frontend Apps>` describes, changes it too deeply to do the work in
+place.  Its main branch still builds a micro-frontend that operators are running
+and that Open edX releases are cut from, so the conversion happens on a long-lived
+``frontend-base`` branch instead, publishing prerelease packages of its own while
+it is in flight and taking ports of the main branch's features and fixes as they
+land.
+
+Eventually the conversion is done, and the repository should become what the
+:term:`Composable Architecture` expects: a publisher of packages composed into a
+:term:`Site`, rather than a deployable application.  Three things have to be
+settled for that to happen.  How the converted branch takes over.  What governs the
+repository's branches afterwards.  And what becomes of the micro-frontend line that
+releases were being cut from, which does not stop mattering the day the conversion
+finishes.
+
+Decision
+********
+
+1. The conversion branch is merged with the "ours" strategy
+===========================================================
+
+A conversion branch is not reconciled with the main branch.  The two have diverged
+across nearly every file, and there is nothing to reconcile in any case, since the
+conversion branch already carries the main branch's features and fixes as ports.
+The merge keeps the conversion branch's tree wholesale while still joining the
+two histories::
+
+  git switch frontend-base
+  git merge -s ours main
+  git switch main
+  git merge --ff-only frontend-base
+  git push origin main
+
+The first merge produces a commit with ``frontend-base``'s tree and both branches
+as parents.  The second is therefore a fast-forward, which is the point: the main
+branch is never rewritten, so clones, open pull requests, and everything already
+pointing into its history survive the merge.  Once it is pushed, the
+``frontend-base`` branch has served its purpose and can be deleted.
+
+2. After merging, OEP-10 governs
+================================
+
+From that moment the repository is subject to
+:ref:`OEP-10 <OEP-10 Open edX Releases>` and its ADRs, with the single exception
+section 3 makes.  The main branch is unstable and publishes alphas, ``stable``
+carries the current stable major on the "latest" dist-tag, and maintenance
+branches are cut as :ref:`ADR 0002 <Frontend Stable Branches>` describes.
+Release participation follows :ref:`ADR 0003 <Frontend Release Strategy>`, which
+is to say by published version rather than by a branch cut at release time.
+
+3. The micro-frontend line continues on legacy-mfe
+==================================================
+
+Immediately before the merge, a long-lived ``legacy-mfe`` branch is cut from the
+main branch's tip.  It carries the micro-frontend the conversion replaces, and it
+is where any further ``release/RELEASENAME`` branches for that micro-frontend are
+cut, should any release still include it.
+
+This is an explicit exception to :ref:`ADR 0003 <Frontend Release Strategy>`.
+A converted repository annotates ``openedx.org/release: "legacy-mfe"``, so that
+release tooling keeps cutting the micro-frontend from that branch while it
+still ships.  The exception lasts only as long as the micro-frontend does: once
+no supported release includes it, the annotation goes to null, ADR 0003 applies
+unmodified, and ``legacy-mfe`` can be archived.
+
+Consequences
+************
+
+Tooling that assumes a repository's release branch is cut from its default
+branch will need attention, since for a converted repository the two are no
+longer the same.
+
+The main branch's first-parent history becomes the conversion branch's, with
+the legacy micro-frontend's history joined on the second parent.  A full ``git
+log`` shows both, while path-limited logs and ``git blame`` only apply to the
+converted code.
+
+Merging is a one-way door for a given repository.  Nothing prevents further work on
+``legacy-mfe``, but the main branch does not go back to building a micro-frontend.
+
+Rejected Alternatives
+*********************
+
+**Merge the conversion branch normally.**  A regular merge would try to combine two
+trees that no longer resemble each other, across nearly every file, and a
+conflict resolution that large is both enormous and pointless: the result wanted is
+simply the conversion branch's tree, which the ``ours`` strategy produces directly.
+
+**Force-push the main branch to the conversion branch's tip.**  This is how
+:ref:`ADR 0002 <Frontend Stable Branches>` moves ``stable`` onto a new major, and
+the objection there does not apply here, since ``legacy-mfe`` would keep the
+outgoing commits either way.  What differs is the branch: this is the repository's
+default branch, so a non-fast-forward move would invalidate every clone and recompute
+every open pull request against unrelated history.  ADR 0002 accepts that cost on
+``stable`` because ``stable`` is consumed from NPM rather than checked out, and pays
+it repeatedly.  Here it would be paid once, on the branch where it hurts most, so
+the ``ours`` merge and its permanent merge commit are the better trade.
+
+References
+**********
+
+* `Land frontend-base <https://github.com/openedx/frontend-base/issues/243>`_, the
+  issue where the merge mechanism was worked out
+
+Change History
+**************
+
+2026-08-12
+==========
+
+* Document created
+* `Pull request #815 <https://github.com/openedx/openedx-proposals/pull/815>`_

--- a/oeps/processes/oep-0010-proc-openedx-releases.rst
+++ b/oeps/processes/oep-0010-proc-openedx-releases.rst
@@ -81,7 +81,10 @@ To be **included** in an Open edX release, a component must meet these
 criteria.
 
 - It must be successfully merged into its repository's release-from branch.
-  This is typically master, though it can be any branch.
+  This is typically master, though it can be any branch.  For a component that
+  a release pins by version rather than by branch (see `Release creation`_
+  below), this means the pinned version must have been published from a branch
+  that is maintained for the life of the release.
 
 - It must be installable in at least one of the supported installation methods.
 
@@ -149,6 +152,24 @@ Releases will be tagged ``release/RELEASENAME.1``,
   * Master branch: ``open-release/RELEASENAME.master``
   * Point releases: ``open-release/RELEASENAME.1``, ``open-release/RELEASENAME.2``, etc
 
+The above applies to components that a release pins by git reference: those that
+are deployed from, or built out of, a checkout of their own repository.  Other
+components are pinned by published version instead, as a dependency declared in
+a manifest belonging to a component that *is* pinned by git reference.  Python
+libraries pinned in ``edx-platform``'s requirements files, and NPM packages
+pinned in a frontend site's ``package.json``, both work this way.
+
+Components pinned by version are not branched or tagged for the release, and
+declare ``openedx.org/release: null`` in their ``catalog-info.yaml``.  The
+record of which version a release pins lives with the depending component, on
+that component's release branch.  Their own branching and versioning policy,
+including how long a given version line keeps receiving fixes, is defined by
+the decisions governing their ecosystem; see `Related Decisions`_ below.
+
+Being pinned by version does not reduce a component's obligations under `Levels
+of support`_.  A component that is supported in a release must keep publishing
+fixes for the version line that release pins, for the life of that release.
+
 Involving repos in the Open edX build process
 =============================================
 
@@ -193,6 +214,13 @@ The following related decisions modify or enhance this OEP, but have not yet bee
 
 Change History
 **************
+
+2026-08-04
+==========
+
+* Distinguish components that a release pins by git reference from those it
+  pins by published version.
+* `Pull request #815 <https://github.com/openedx/openedx-proposals/pull/815>`_
 
 2025-08-24
 ==========

--- a/oeps/processes/oep-0010/decisions/0002-frontend-stable-branches.rst
+++ b/oeps/processes/oep-0010/decisions/0002-frontend-stable-branches.rst
@@ -1,0 +1,233 @@
+.. _Frontend Stable Branches:
+
+0002. Frontend Stable Branches
+##############################
+
+Status
+******
+
+**Accepted**
+
+Context
+*******
+
+Semantically-released frontend repositories in the Open edX org need a rallying
+point where new features integrate: a place where developers have enough leeway
+to push the envelope and fix bugs without having the code immediately shipped
+to thousands of users.  That branch is commonly called "master" or "main" in
+projects that follow the "main is unstable" strategy; others call it "next",
+"develop", or "alpha".  What is almost universal is that at least one branch
+serves this purpose.
+
+In contrast, main branches here have historically been deemed stable, with every
+commit that lands expected to be production ready.  Most repositories have no
+"next" branch either.
+
+At the other end of the spectrum, consumers who are not ready for a new major
+version of a package still need fixes for the one they are on.  A single stable
+branch cannot serve them: once it has moved on, the versions they are running
+have nowhere to be patched from.  The structure therefore has to include lines
+that outlive the current stable major, each publishing on its own.
+
+What follows settles which branches such a repository has, what each of them
+publishes, and how changes travel between them.  Which of those lines a given
+Open edX release depends on, and for how long, is settled by
+:ref:`ADR 0003 <Frontend Release Strategy>`.
+
+Decision
+********
+
+The following decisions apply to any frontend repository in the Open edX org
+once it starts publishing to NPM with ``semantic-release``.
+
+1. Main is unstable
+===================
+
+A repository's main branch is deemed unstable. This has two major consequences:
+
+1. Using the main branch in production is not supported;
+2. The DEPR process does not apply to it; breaking changes can land with no
+   warning.
+
+Notably, though, the main branch retains the following properties:
+
+1. New features should be developed for and merged to it before any other
+   branch;
+2. To facilitate collaboration, it is never rebased.
+
+2. Publication of the main branch
+=================================
+
+A repository's main branch is published semantically to NPM on an "alpha"
+prerelease tag, with a monotonically incremented number suffix.  For instance::
+
+  frontend-base@2.0.0-alpha.4
+  frontend-app-instructor-dashboard@2.0.0-alpha.2
+
+3. Stable and maintenance branches
+==================================
+
+Stable code is published from a long-lived ``stable`` branch, which always
+carries the newest stable major.  It owns the NPM "latest" dist-tag and is
+published semantically, with no breaking changes allowed after publication::
+
+  frontend-base@1.0.5
+  frontend-app-instructor-dashboard@1.4.3
+
+When the main branch contains breaking changes over what ``stable`` carries
+and is deemed ready for widespread use, its work graduates onto ``stable`` as
+the next major (see `4. Graduating main onto stable`_).  To continue maintaining
+the previous major, an "n.x" branch is cut from
+its last tag, where "n" is that major's number and the ".x" is literal.  For
+instance, once ``stable`` has moved from the 1.x line to the 2.x line, a ``1.x``
+branch is cut at the last 1.x tag::
+
+  stable    2.0.0, 2.1.0, ...    (dist-tag: latest)
+  1.x       1.4.3, 1.5.0, ...    (dist-tag: 1.x)
+
+These maintenance branches are also published semantically, with no breaking
+changes allowed.  Each one owns the NPM dist-tag matching its own name, which
+is what keeps "latest" pointing at ``stable``. Consumers, for their part,
+select a maintained major by semver range::
+
+  "@openedx/frontend-base": "1.x"
+
+An "n.x" branch accepts both new minors and patches within its major.  To patch a
+minor that the line carrying it has moved past, whether that line is ``stable``
+or an "n.x" branch, an "n.m.x" branch is cut from that minor's last tag, where "m"
+is the minor's number.  These are patch-only: a
+feature landing on one still results in a patch release.  Continuing the example
+above, with 1.5.0 already shipped from ``1.x``, a ``1.4.x`` branch cut at the last
+1.4 tag carries on the 1.4 line::
+
+  stable    2.0.0, 2.1.0, ...    (dist-tag: latest)
+  1.x       1.5.0, 1.6.0, ...    (dist-tag: 1.x)
+  1.4.x     1.4.4, 1.4.5, ...    (dist-tag: 1.4.x)
+
+4. Graduating main onto stable
+==============================
+
+Graduation is the moment ``stable`` stops carrying one major and starts carrying
+the next.  It cannot be a fast-forward: by then ``stable`` holds cherry-picked
+backports that are not on the main branch, so the two have diverged.
+
+Rather than reconcile that divergence, graduation retires the branch.  The
+outgoing line keeps its history under its "n.x" name, and ``stable`` is
+re-pointed at the main branch's tip::
+
+  git push origin stable:1.x
+  git push --force origin main:stable
+
+Cutting the "n.x" branch of `3. Stable and maintenance branches`_ and retiring the
+old ``stable`` are therefore the same act.  Since the second push rewrites a
+published branch, graduation is a deliberate push by a maintainer rather than a
+PR.
+
+5. Backports
+============
+
+All changes, including bug fixes and security patches, should target the main
+branch first.  Once merged, they can be backported to ``stable`` and to the
+appropriate maintenance branches.  This "main first" approach ensures that fixes
+are never lost when a new line is cut: they are part of the main branch's
+history and will naturally flow into future releases.
+
+The only foreseeable scenario where a change may land on ``stable`` or a
+maintenance branch without a corresponding change landing on the main branch
+first is when the latter has diverged enough that the fix or feature no longer
+applies to it, because the affected code has been removed or rewritten.
+
+The flow, by kind of change:
+
+Breaking change
+  Lands on the main branch, and stops there (until the entire main
+  branch is deemed stable and subsequently released.)
+
+New feature
+  Lands on the main branch.  It may be backported to ``stable`` and to an
+  ``n.x`` branch when the new feature is stable and there is a specific reason
+  to do so, such as Product demand; not all non-breaking features will be.
+  These features stop at ``n.x``.
+
+Bug fix
+  Lands on the main branch, and is backported to ``stable`` and to every
+  ``n.x`` and ``n.m.x`` branch still under support (see
+  :ref:`ADR 0003 <Frontend Release Strategy>`).
+
+Two backport methods are available, in order of preference:
+
+Fast-forward merge
+  If no breaking changes have landed on the default branch since ``stable`` was
+  last updated, fast-forward it to the current tip.  This brings in all
+  intermediate commits, and is the ideal approach early in a release cycle,
+  before the two have meaningfully diverged.
+
+Cherry-pick
+  When the default branch contains breaking changes that must not reach
+  ``stable``, cherry-pick individual merge commits instead, resolving conflicts
+  or reworking the change as needed.  This is the most common method once the
+  branches have started to diverge.
+
+Regardless of the method, backports are submitted as PRs against the target
+branch, and the PR description should reference the original one for
+traceability.
+
+Consequences
+************
+
+Operators and developers who track a main branch get no warning before a
+breaking change, and no DEPR process to lean on.  The alpha dist-tag exists so
+that this is an explicit choice rather than an accident.
+
+The cost is branch count and backport work.  Every maintained line is a branch
+somebody has to cut at the right tag and backport to, and the number of live lines
+grows with how many majors and minors remain under support.  The "main first" rule
+keeps this tractable, but it does not make it free.
+
+``stable`` also moves non-fast-forward once per major, so its branch protection
+has to leave room for whoever performs a graduation, and anyone holding a clone of
+it has to reset when one lands.  No history is lost in the move, since the
+outgoing commits keep a branch of their own.
+
+Rejected Alternatives
+*********************
+
+**Keep every main branch production ready.**  This is the org's historical
+practice, and it leaves concurrent breaking work with nowhere to integrate.  Two
+features that need to evolve together, each breaking on its own, either ship to
+users before they are ready or are developed in isolation and reconciled late.
+
+**Merge the main branch into stable.**  Resolving in the main branch's
+favor with ``-X theirs`` does not actually produce its tree, since that option
+only settles conflicting hunks: files changed on ``stable`` alone survive into the
+result.  Even done correctly, the merge commit would sit on ``stable`` rather than
+on the main branch, leaving ``stable`` ahead of it.  No later backport could then
+be a fast-forward, and the main branch would go on deriving its alphas from the
+tag ``stable`` carried before graduation, publishing them below the major that
+was just released.
+
+**Graduate with an ``ours`` merge onto the main branch.**  Merging ``stable`` into
+the main branch with the ``ours`` strategy yields a commit that keeps the main
+branch's tree while recording ``stable`` as a second parent, after which
+``stable`` fast-forwards onto it and never moves backwards.  It works, but the
+main branch pays: it carries a permanent merge commit whose second parent
+claims content the strategy discarded, so every backport shows up twice in
+``git log``.
+
+**Commit the main branch's tree onto stable as a single commit.**  Resetting
+``stable``'s tree to the main branch's and committing keeps ``stable``
+fast-forwardable and leaves the main branch alone, but the main branch's commits
+never become ancestors of ``stable``.  The new major's release notes collapse to
+that one commit, its version turns on how the message is worded rather than on the
+history behind it, and because ``stable`` stops being an ancestor of the main
+branch, later backports cannot fast-forward and the main branch cannot see the new
+major's tag.
+
+Change History
+**************
+
+2026-08-04
+##########
+
+* Document created
+* `Pull request #815 <https://github.com/openedx/openedx-proposals/pull/815>`_

--- a/oeps/processes/oep-0010/decisions/0003-frontend-release-strategy.rst
+++ b/oeps/processes/oep-0010/decisions/0003-frontend-release-strategy.rst
@@ -1,0 +1,153 @@
+.. _Frontend Release Strategy:
+
+0003. Frontend Release Strategy
+###############################
+
+Status
+******
+
+**Accepted**
+
+Context
+*******
+
+One question drives this ADR: how does a semantically-released frontend
+repository participate in an Open edX release?
+
+:ref:`OEP-10 <OEP-10 Open edX Releases>` pins a repository into a release by
+cutting a ``release/RELEASENAME`` branch and tagging it.  That works for
+repositories which are deployed from, or built out of, a checkout of
+themselves.  But :ref:`OEP-65 <OEP-65 Frontend Composability>` changes what a
+frontend repository is: apps are published as NPM packages and composed into a
+:term:`Site` at build time, alongside ``frontend-base`` itself.  The Site is the
+deployable artifact; everything it is built from is resolved from NPM by version.
+
+For an app repository, cutting a ``release/RELEASENAME`` branch does not survive
+that change.  Nothing deploys from such a branch, because an app is no longer
+deployed; it is compiled into a Site.  Nothing consumes it either, because a Site
+names its apps by version range in ``package.json``, and a version range does not
+select a branch.  The branch would be inert: cutting it, or forgetting to, makes
+no difference to what an operator installs, because what a release ships is
+decided by the Site's lockfile either way.
+
+Participation therefore has to be by published version.
+:ref:`ADR 0002 <Frontend Stable Branches>` establishes the lines those versions
+come from: a ``stable`` branch carrying the current stable major, and ``n.x`` and
+``n.m.x`` branches carrying the ones still maintained.  What remains is which
+repositories get branched for a release and which do not, what the branched ones
+record, what dependency ranges they carry, and which lines end up pinned and for
+how long.
+
+Decision
+********
+
+1. Frontend package repositories are not branched or tagged
+===========================================================
+
+Repositories whose release artifact is a package published to NPM are not
+branched or tagged for Open edX releases.  This covers ``frontend-base``, the
+shared libraries, and every app repository built on ``frontend-base``.  Each
+declares ``openedx.org/release: null`` in its ``catalog-info.yaml``.
+
+They participate by published version instead.  Which version, and how it is
+recorded, follows from the next two sections.
+
+2. frontend-template-site is branched and tagged
+================================================
+
+``frontend-template-site`` is branched and tagged in the ordinary OEP-10 way: it
+keeps ``openedx.org/release`` pointing at its default branch, and gets a
+``release/RELEASENAME`` branch at cutoff.  It is the only frontend repository in
+the release that does.
+
+Its ``package.json`` and ``package-lock.json``, on that branch, are the
+authoritative record of which frontend versions the release ships.  There is no
+separate manifest to maintain.
+
+Operators maintain their own Sites, which are not part of the release and are not
+bound by any of this, though one derived from the template will usually want to
+follow the same pattern.
+
+3. The release/RELEASENAME branch takes patch-level ranges
+==========================================================
+
+By definition, new features shouldn't be added to stable releases. Thus, on
+``frontend-template-site``'s ``release/RELEASENAME`` branch, direct dependencies
+on apps and on ``frontend-base`` are expressed as x-ranges constrained to specific
+feature levels.  The branch then accepts patches from each maintenance line, but
+declines minor version updates::
+
+  "dependencies": {
+    "@openedx/frontend-app-authn": "1.0.x",
+    "@openedx/frontend-app-instructor-dashboard": "1.2.x",
+    "@openedx/frontend-base": "1.0.x"
+  }
+
+Its main branch is unaffected: it keeps caret ranges, which are a deliberate
+choice there, letting new minors arrive without a PR to every ``package.json``.
+
+4. Maintenance branches carry the release's support window
+==========================================================
+
+The minor each package is pinned at is whatever was most recently published when
+the branch was cut, as captured in ``frontend-template-site``'s lockfile.  Those
+minors determine which ``n.x`` and ``n.m.x`` branches have to exist: a release
+pinned at 1.4 once the line carrying it has moved on to 1.5 needs a ``1.4.x``
+branch to patch from.  Those branches must keep receiving fixes for the life of
+the release, which per OEP-10 is until the following release, or about six months.
+
+This is how a package that is not branched for a release still meets OEP-10's
+criteria for being *supported* in it.
+
+Consequences
+************
+
+App repositories that today annotate ``openedx.org/release: "master"`` flip to
+null as they move onto ``frontend-base`` and into Sites.  The release tooling in
+``repo-tools`` will stop cutting and tagging branches in them, and should be
+checked for anything that assumes every included component has a
+``release/RELEASENAME`` branch.
+
+Operators tracking a release branch of their Site receive bug fixes from each
+maintenance line without any change to their ``package.json``, and receive
+features only by editing it.  This makes taking a feature onto a release branch a
+deliberate act, which is the point, but it also means an operator who wants one
+must know which minor it landed in.
+
+Every release under support holds its pinned lines open, so the branch and
+backport cost scales with how many releases are supported at once.
+
+Rejected Alternatives
+*********************
+
+**Cut release branches in frontend package repositories anyway.**  The status quo
+for app repositories.  Beyond being inert, it is incompatible with the scheme
+:ref:`ADR 0002 <Frontend Stable Branches>` sets out, in which every branch owns a
+version line and each version is derived from history.  A branch named for a
+calendar release owns no version line, so anything published from it would land in
+a line another branch already owns.  A dist-tag marks a release's version without
+needing a branch at all.
+
+**Have frontend-template-site depend on an app's branch rather than a version.**
+The other way to give a branch effect, and incompatible with consuming these
+repositories as published packages.  A release pins the artifact on the registry;
+a branch is source that was never published, so it carries no real version.
+
+**Pin exact versions on the release branch.**  This would require a PR to
+``frontend-template-site`` for every patch of every app it composes, and buys
+nothing: patches are non-breaking by definition, and the lockfile already records
+exactly what a given build resolved.
+
+**Keep caret ranges on the release branch.**  A caret lets the lockfile pick up a
+new minor with no change to ``package.json``, so a released branch can start
+shipping features nobody assessed against its backend, and can do so without any
+reviewable change to the repository.
+
+Change History
+**************
+
+2026-08-04
+##########
+
+* Document created
+* `Pull request #815 <https://github.com/openedx/openedx-proposals/pull/815>`_


### PR DESCRIPTION
### Description

OEP-10 pins a repository into a release by cutting a `release/RELEASENAME` branch and tagging it, which works for components that are deployed from, or built out of, a checkout of themselves. Under OEP-65 a frontend app is neither: it is published as an NPM package and composed into a Site at build time. A release branch in an app repository would be inert, since nothing deploys from it and nothing consumes it. Nothing in this repo currently says how such a repository participates in a release instead.

The first change is to OEP-10 itself, which now distinguishes components that a release pins by git reference from those it pins by published version. It says where the record of a pinned version lives, and that being pinned by version does not lower a component's obligations under levels of support. None of this is frontend-specific: Python libraries pinned in `edx-platform`'s requirements files work the same way.

Three ADRs follow from that. Under OEP-10, ADR 0002 (moved here from [frontend-base's ADR 0012](https://github.com/openedx/frontend-base/blob/main/docs/decisions/0012-frontend-branching-strategy.rst)) settles what branches a semantically-released frontend repository has, what each of them publishes, how changes travel between them, and how the `stable` branch moves onto a new major once the main branch is ready for one. ADR 0003 settles how such a repository takes part in an Open edX release, which is by published version rather than by a branch cut at release time.

Under OEP-65, ADR 0004 settles how an app repository's `frontend-base` conversion branch takes over as its main branch, that the OEP-10 ADRs govern its branches from that point on, and where the micro-frontend it replaces continues to live.

### LLM usage notice

Built with assistance from Claude.


Closes openedx/public-engineering#564
